### PR TITLE
Create PianoInputField, bump min iOS version to 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "PianoKeyboard",
     platforms: [
-        .iOS("15.0")
+        .iOS("17.0")
     ],
     products: [
         .library(

--- a/Source/PianoInputField.swift
+++ b/Source/PianoInputField.swift
@@ -1,0 +1,53 @@
+//
+//  PianoInputField.swift
+//  PianoKeyboard
+//
+//  Created by Evan Templeton on 5/2/25.
+//
+
+import SwiftUI
+
+public struct PianoInputField: View {
+    @StateObject private var viewModel = PianoKeyboardViewModel()
+    @Binding private var keysPressed: [String]
+    
+    public init(keysPressed: Binding<[String]>) {
+        self._keysPressed = keysPressed
+    }
+    
+    public var body: some View {
+        PianoKeyboardView(viewModel: viewModel, style: ClassicStyle())
+            .onChange(of: viewModel.pressedKeys) { oldKeys, newKeys in
+                if newKeys != oldKeys {
+                    keysPressed = newKeys
+                }
+            }
+    }
+}
+
+private extension PianoInputField {
+    struct ExampleView: View {
+        @State private var keysPressed: [String] = []
+        var body: some View {
+            VStack {
+                Color.white
+                HStack {
+                    if !keysPressed.isEmpty {
+                        ForEach(keysPressed, id: \.self) { key in
+                            Text(key)
+                        }
+                    } else {
+                        Text("Press a key...")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal)
+                PianoInputField(keysPressed: $keysPressed)
+            }
+        }
+    }
+}
+
+#Preview {
+    PianoInputField.ExampleView()
+}

--- a/Source/PianoKeyboardViewModel.swift
+++ b/Source/PianoKeyboardViewModel.swift
@@ -19,6 +19,8 @@ public class PianoKeyboardViewModel: ObservableObject, PianoKeyViewModelDelegate
     @Published public var latch = false {
         didSet { reset() }
     }
+    
+    @Published public var pressedKeys: [String] = []
 
     public var keyRects: [CGRect] = []
     public weak var delegate: PianoKeyboardDelegate?
@@ -67,32 +69,46 @@ public class PianoKeyboardViewModel: ObservableObject, PianoKeyViewModelDelegate
                     let keyLatched = keys[index].latched
 
                     if keyDownAt[index] && keyLatched {
-                        delegate?.pianoKeyUp(noteNumber)
+                        keyUp(noteNumber)
                         keys[index].latched = false
                         keys[index].touchDown = false
                     }
                     if keyDownAt[index] && !keyLatched {
-                        delegate?.pianoKeyDown(noteNumber)
+                        keyDown(noteNumber)
                         keys[index].latched = true
                         keys[index].touchDown = true
                     }
 
                 } else {
                     if keyDownAt[index] {
-                        delegate?.pianoKeyDown(noteNumber)
+                        keyDown(noteNumber)
                     } else {
-                        delegate?.pianoKeyUp(noteNumber)
+                        keyUp(noteNumber)
                     }
                     keys[index].touchDown = keyDownAt[index]
                 }
             } else {
                 if keys[index].touchDown && keyDownAt[index] && keys[index].latched {
-                    delegate?.pianoKeyUp(noteNumber)
+                    keyUp(noteNumber)
                     keys[index].latched = false
                     keys[index].touchDown = false
                 }
             }
         }
+    }
+    
+    private func keyDown(_ number: Int) {
+        pressedKeys.append(Note.name(for: number))
+        delegate?.pianoKeyDown(number)
+    }
+    
+    private func keyUp(_ number: Int) {
+        let note = Note.name(for: number)
+        guard let index = pressedKeys.firstIndex(of: note) else {
+            return
+        }
+        pressedKeys.remove(at: index)
+        delegate?.pianoKeyUp(number)
     }
 
     private func getKeyContaining(_ point: CGPoint) -> Int? {
@@ -112,7 +128,7 @@ public class PianoKeyboardViewModel: ObservableObject, PianoKeyViewModelDelegate
         for i in 0..<numberOfKeys {
             keys[i].touchDown = false
             keys[i].latched = false
-            delegate?.pianoKeyUp(keys[i].noteNumber)
+            keyUp(keys[i].noteNumber)
         }
     }
 }


### PR DESCRIPTION
- Add a new component `PianoInputField` that publishes pressed keys, similar to `TextField`.
- Bump minimum iOS version to iOS 17